### PR TITLE
Added general gitignore for the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+
+TODO
+*~
+rhipe-java.log
+.Rhistory
+
+# Mac crap
+.DS_Store
+.Rapp.history	
+
+# Data files
+*.csv
+*.RData
+*.json
+*.gz
+*.txt
+*.feather
+tmp/
+
+# python crap
+*.pyc
+
+# Knitr caching
+*_cache/
+*_files/
+
+# IPython notebook checkpoints
+.ipynb_checkpoints
+*.log


### PR DESCRIPTION
Let's add a top-level gitignore. The main things this does is drop `.pyc` files, and protect against accidentally committing data files.